### PR TITLE
Fix Jekyll front matter titles

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: about:mike
+title: "about:mike"
 nav: about
 ---
 

--- a/categories/android-tv.html
+++ b/categories/android-tv.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: Android TV Projects
+title: "Mike Frolov: Android TV Projects"
 nav: portfolio
 ---
 <div class="hero small">

--- a/categories/flutter.html
+++ b/categories/flutter.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: Flutter Projects
+title: "Mike Frolov: Flutter Projects"
 nav: portfolio
 ---
 <div class="hero small">

--- a/categories/native.html
+++ b/categories/native.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: Native Projects
+title: "Mike Frolov: Native Projects"
 nav: portfolio
 ---
 <div class="hero small">

--- a/companies/100am.html
+++ b/companies/100am.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: 100AM Projects
+title: "Mike Frolov: 100AM Projects"
 nav: portfolio
 ---
 <div class="hero small">

--- a/companies/butik.html
+++ b/companies/butik.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: BUTIK Projects
+title: "Mike Frolov: BUTIK Projects"
 nav: portfolio
 ---
 <div class="hero small">

--- a/companies/corespirit.html
+++ b/companies/corespirit.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: CoreSpirit Projects
+title: "Mike Frolov: CoreSpirit Projects"
 nav: portfolio
 ---
 <div class="hero small">

--- a/companies/getmark.html
+++ b/companies/getmark.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: GetMark Projects
+title: "Mike Frolov: GetMark Projects"
 nav: portfolio
 ---
 <div class="hero small">

--- a/companies/own.html
+++ b/companies/own.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: Own projects Projects
+title: "Mike Frolov: Own projects Projects"
 nav: portfolio
 ---
 <div class="hero small">

--- a/companies/sibriver.html
+++ b/companies/sibriver.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: Sibriver Projects
+title: "Mike Frolov: Sibriver Projects"
 nav: portfolio
 ---
 <div class="hero small">

--- a/companies/tobox.html
+++ b/companies/tobox.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: ToBox Projects
+title: "Mike Frolov: ToBox Projects"
 nav: portfolio
 ---
 <div class="hero small">

--- a/projects/100am.html
+++ b/projects/100am.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: 100AM Project
+title: "Mike Frolov: 100AM Project"
 nav: portfolio
 ---
 <div class="hero project-page">

--- a/projects/alert-button.html
+++ b/projects/alert-button.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: Alert button Project
+title: "Mike Frolov: Alert button Project"
 nav: portfolio
 ---
 <div class="hero project-page">

--- a/projects/bubuka.html
+++ b/projects/bubuka.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: Bubuka Project
+title: "Mike Frolov: Bubuka Project"
 nav: portfolio
 ---
 <div class="hero project-page">

--- a/projects/bus-track.html
+++ b/projects/bus-track.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: BusTrack Project
+title: "Mike Frolov: BusTrack Project"
 nav: portfolio
 ---
 <div class="hero project-page">

--- a/projects/butik-fit-assist.html
+++ b/projects/butik-fit-assist.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: Butik Fit-Assist Project
+title: "Mike Frolov: Butik Fit-Assist Project"
 nav: portfolio
 ---
 <div class="hero project-page">

--- a/projects/butik-queue.html
+++ b/projects/butik-queue.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: Butik Fitting-Queue Project
+title: "Mike Frolov: Butik Fitting-Queue Project"
 nav: portfolio
 ---
 <div class="hero project-page">

--- a/projects/butik-sale-assist.html
+++ b/projects/butik-sale-assist.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: Butik Sale-Assist Project
+title: "Mike Frolov: Butik Sale-Assist Project"
 nav: portfolio
 ---
 <div class="hero project-page">

--- a/projects/butik.html
+++ b/projects/butik.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: Butik Customer App Project
+title: "Mike Frolov: Butik Customer App Project"
 nav: portfolio
 ---
 <div class="hero project-page">

--- a/projects/coinface.html
+++ b/projects/coinface.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: Coinface Project
+title: "Mike Frolov: Coinface Project"
 nav: portfolio
 ---
 <div class="hero project-page">

--- a/projects/corespirit.html
+++ b/projects/corespirit.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: CoreSpirit Project
+title: "Mike Frolov: CoreSpirit Project"
 nav: portfolio
 ---
 <div class="hero project-page">

--- a/projects/getmark.html
+++ b/projects/getmark.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: GetMark Project
+title: "Mike Frolov: GetMark Project"
 nav: portfolio
 ---
 <div class="hero project-page">

--- a/projects/habit.html
+++ b/projects/habit.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: Habit App Project
+title: "Mike Frolov: Habit App Project"
 nav: portfolio
 ---
 <div class="hero project-page">

--- a/projects/klisma.html
+++ b/projects/klisma.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: Klisma Project
+title: "Mike Frolov: Klisma Project"
 nav: portfolio
 ---
 <div class="hero project-page">

--- a/projects/loyalty-demo.html
+++ b/projects/loyalty-demo.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: Loyalty Demo Project
+title: "Mike Frolov: Loyalty Demo Project"
 nav: portfolio
 ---
 <div class="hero project-page">

--- a/projects/morgan-taylor.html
+++ b/projects/morgan-taylor.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: Morgan Taylor Virtual Salon Project
+title: "Mike Frolov: Morgan Taylor Virtual Salon Project"
 nav: portfolio
 ---
 <div class="hero project-page">

--- a/projects/mountive.html
+++ b/projects/mountive.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: Mountive Project
+title: "Mike Frolov: Mountive Project"
 nav: portfolio
 ---
 <div class="hero project-page">

--- a/projects/shadowsocks.html
+++ b/projects/shadowsocks.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: Shadowsocks Project
+title: "Mike Frolov: Shadowsocks Project"
 nav: portfolio
 ---
 <div class="hero project-page">

--- a/projects/tobox.html
+++ b/projects/tobox.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Frolov: ToBox Project
+title: "Mike Frolov: ToBox Project"
 nav: portfolio
 ---
 <div class="hero project-page">


### PR DESCRIPTION
## Summary
- fix YAML syntax in front matter by quoting titles containing a colon

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686880a255d48327a3537de049759f26